### PR TITLE
Fix support for USB forwarding

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -11,6 +11,7 @@ arch=('x86_64')
 license=('custom:Teradici')
 depends=('pcsclite' 'qt5-declarative' 'qt5-quickcontrols')
 makedepends=('fakeroot')
+install=$pkgname.install
 #options=(!strip)
 source=("https://downloads.teradici.com/ubuntu/pool/non-free/p/pcoip-client/pcoip-client_${pkgver}-18.04_amd64.deb"
  "http://se.archive.ubuntu.com/ubuntu/pool/main/p/protobuf/libprotobuf10_3.0.0-9.1ubuntu1_amd64.deb"

--- a/pcoip-client.install
+++ b/pcoip-client.install
@@ -1,0 +1,4 @@
+post_install() {
+    setcap "cap_setgid+p" "/usr/bin/pcoip-client"
+    setcap "cap_setgid+i" "/usr/libexec/pcoip-client/usb-helper"
+}


### PR DESCRIPTION
This should fix support for USB device forwarding. Setcap arguments were taken directly from the ubuntu .deb.