### PR TITLE
Update anyware domain name

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,7 +13,7 @@ depends=('openssl-1.1' 'pcsclite' 'qt5-networkauth' 'qt5-declarative' 'qt5-quick
 makedepends=('fakeroot' 'patchelf')
 install=$pkgname.install
 #options=(!strip)
-source=("https://dl.teradici.com/DeAdBCiUYInHcSTy/pcoip-client/deb/ubuntu/pool/jammy/main/p/pc/pcoip-client_${pkgver}-${_ubuntuver}/pcoip-client_${pkgver}-${_ubuntuver}_amd64.deb"
+source=("https://dl.anyware.hp.com/DeAdBCiUYInHcSTy/pcoip-client/deb/ubuntu/pool/jammy/main/p/pc/pcoip-client_${pkgver}-${_ubuntuver}/pcoip-client_${pkgver}-${_ubuntuver}_amd64.deb"
  "http://se.archive.ubuntu.com/ubuntu/pool/main/p/protobuf/libprotobuf23_3.12.4-1ubuntu7_amd64.deb"
  "http://se.archive.ubuntu.com/ubuntu/pool/universe/h/hiredis/libhiredis0.14_0.14.1-2_amd64.deb"
 )


### PR DESCRIPTION
The dl.teradici.com domain has been deprecated and is inactive as of Oct 1 2025, as announced [here](https://anyware.hp.com/knowledge/deprecation-of-dl.teradici.com-effective-october-1-2025-here-is-what-you-need-to-know) 

I changed the domain in the code for this new one and managed to install.